### PR TITLE
Feature/as/add comps

### DIFF
--- a/validation_json/validation_rules_schema.json
+++ b/validation_json/validation_rules_schema.json
@@ -126,12 +126,33 @@
             ]
         },
         "species": {
-            "type": "string",
             "required": true,
             "allowed": [
                 "Homo sapiens",
                 "Mus musculus"
             ]
+        },
+        "total_reads": {
+            "required": true,
+            "nullable": true
+        },
+        "flow_cell_barcode": {
+            "required": true,
+            "dependencies": {
+                "file_format": [
+                    "FASTQ"
+                ]
+            },
+            "nullable": true
+        },
+        "lane_number": {
+            "required": true,
+            "dependencies": {
+                "file_format": [
+                    "FASTQ"
+                ]
+            },
+            "nullable": true
         }
     },
     "DNAseq_rules": {


### PR DESCRIPTION
Closes: #10 , #11 , and https://github.com/childrens-bti/file-manifest-shiny/issues/9

This PR:
- removes flowcell_barcode, lane_number, and total_reads
- adds new compositions
- adds a new species field