### PR TITLE
Add image file extensions to validator json for Visium HD Spatial libraries

### DIFF
--- a/validation_json/validation_rules_schema.json
+++ b/validation_json/validation_rules_schema.json
@@ -71,6 +71,7 @@
                 "TIF",
                 "TIFF",
                 "BTF",
+                "BIGTIFF",
                 "raw"
             ]
         },

--- a/validation_json/validation_rules_schema.json
+++ b/validation_json/validation_rules_schema.json
@@ -68,6 +68,9 @@
                 "TAR",
                 "TSV",
                 "mzML",
+                "TIF",
+                "TIFF",
+                "BTF",
                 "raw"
             ]
         },


### PR DESCRIPTION
Added:
- TIF
- TIFF
- BTF
- BIGTIFF