### PR TITLE
Add Spatial Transcriptomics as allowed experiment_strategy 

### DIFF
--- a/docs/single_cell_spatial_manifest_template.md
+++ b/docs/single_cell_spatial_manifest_template.md
@@ -18,7 +18,7 @@
 | sequencing_center | True | Name of the center generating sequencing data | | string | Harvard Med School | |
 | platform | True | Name of the platform used to obtain data | "Complete Genomics", "Illumina", "Ion Torrent", "LS454", "SOLiD", "ONT", "DNBSEQ", "Other" | string | Illumina | |
 | instrument_model | False | Specific model of sequencing instrument used. | string | Model name of the instrument used for sequencing | NovaSeq 6000 | |
-| experimental_strategy | True | The sequencing strategy used to generate the data file. | "scRNA-Seq", "snRNA-Seq" | string | scRNA-Seq | |
+| experimental_strategy | True | The sequencing strategy used to generate the data file. | "scRNA-Seq", "snRNA-Seq", "Spatial Transcriptomics" | string | scRNA-Seq | |
 | assay_type | True | Chemistry used to generate Visium expression signal (poly(A) capture vs targeted probe capture) | | string | Probe_Based_GEX | |
 | library_type | True | Specify the library modality. | "GEX" | string | GEX | |
 | library_selection | True | Library selection method. | "Affinity Enrichment", "Hybrid Selection", "miRNA Size Fractionation", "PCR", "Poly-T Enrichment", "Random","rRNA Depletion", "Ribosome-protected fragments", "Other" | string | PCT | |

--- a/validation_json/validation_rules_schema.json
+++ b/validation_json/validation_rules_schema.json
@@ -411,7 +411,8 @@
             "dependencies": {
                 "experimental_strategy": [
                     "scRNA-Seq",
-                    "snRNA-Seq"
+                    "snRNA-Seq",
+                    "Spatial Transcriptomics"
                 ]
             }
         },
@@ -437,7 +438,8 @@
             "snRNA-Seq",
             "CITE-Seq",
             "scTCR-Seq",
-            "scBCR-Seq"
+            "scBCR-Seq",
+            "Spatial Transcriptomics"
           ]
         },
         "chain_type": {
@@ -474,7 +476,7 @@
                 {
                     "allowed": ["GEX"],
                     "dependencies": {
-                        "experimental_strategy": ["scRNA-Seq", "snRNA-Seq"]
+                        "experimental_strategy": ["scRNA-Seq", "snRNA-Seq", "Spatial Transcriptomics"]
                     }
                 },
                 {
@@ -575,7 +577,8 @@
             "dependencies": {
                 "experimental_strategy": [
                     "scRNA-Seq",
-                    "snRNA-Seq"
+                    "snRNA-Seq",
+                    "Spatial Transcriptomics"
                 ]
             }
         },
@@ -611,7 +614,8 @@
             "dependencies": {
                 "experimental_strategy": [
                     "scRNA-Seq",
-                    "snRNA-Seq"
+                    "snRNA-Seq",
+                    "Spatial Transcriptomics"
                 ]
             }
         },
@@ -621,7 +625,8 @@
             "dependencies": {
                 "experimental_strategy": [
                     "scRNA-Seq",
-                    "snRNA-Seq"
+                    "snRNA-Seq",
+                    "Spatial Transcriptomics"
                 ]
             }
         },
@@ -691,7 +696,8 @@
                 "experimental_strategy": [
                     "CITE-Seq",
                     "scTCR-Seq",
-                    "scBCR-Seq"
+                    "scBCR-Seq",
+                    "Spatial Transcriptomics"
                 ]
             }
         },
@@ -707,7 +713,8 @@
             "dependencies": {
                 "experimental_strategy": [
                     "scRNA-Seq",
-                    "snRNA-Seq"
+                    "snRNA-Seq",
+                    "Spatial Transcriptomics"
                 ]
             }
         },
@@ -717,7 +724,8 @@
             "dependencies": {
                 "experimental_strategy": [
                     "scRNA-Seq",
-                    "snRNA-Seq"
+                    "snRNA-Seq",
+                    "Spatial Transcriptomics"
                 ]
             }
         },
@@ -734,7 +742,8 @@
             "dependencies": {
                 "experimental_strategy": [
                     "scRNA-Seq",
-                    "snRNA-Seq"
+                    "snRNA-Seq",
+                    "Spatial Transcriptomics"
                 ]
             }
         }


### PR DESCRIPTION
Adds "Spatial Transcriptomics" as an allowed single-cell experimental strategy, including GEX library type support and spatial field validation dependencies. Updates the spatial manifest docs to include the new strategy value.

closes #79 